### PR TITLE
Need to add docValues="true" to title field

### DIFF
--- a/schema_metadata.xml
+++ b/schema_metadata.xml
@@ -37,7 +37,7 @@
     <field indexed="true" multiValued="true" name="also_bought" stored="true" type="TextField"/>
     <field indexed="true" multiValued="true" name="categories" stored="true" type="TextField"/>
     <field indexed="true" multiValued="false" name="price" stored="true" type="TrieDoubleField"/>
-    <field indexed="true" multiValued="false" name="title" stored="true" type="TextField"/>
+    <field indexed="true" multiValued="false" name="title" stored="true" docValues="true" type="TextField"/>
     <field indexed="true" multiValued="false" name="textsuggest" stored="false" type="autocomplete_edge"/>
     <copyField source="title" dest="textsuggest" />
   </fields>


### PR DESCRIPTION
Currently, the below solr_query failed in our DSPN DataStax Day's Lab 5 (Solr) without adding the docValues="true" in the title field schema definition.  Pls accept my change to fix this issue.

SELECT \* FROM retailer.metadata WHERE solr_query='{"q":"title:Noir~", "fq":"categories:Books", "sort":"title asc"}' limit 10;
